### PR TITLE
fix: unwrapping tokens during transfer

### DIFF
--- a/script/upgrade/Migrator.sol
+++ b/script/upgrade/Migrator.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { ERC1967Utils } from "../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+contract Migrator {
+    address public immutable newImplementation;
+
+    constructor(address newImplementation_) {
+        newImplementation = newImplementation_;
+    }
+
+    fallback() external virtual {
+        // Prevent "Assembly access to immutable variables is not supported" error
+        address newImplementation_ = newImplementation;
+        bytes32 implementationSlot_ = ERC1967Utils.IMPLEMENTATION_SLOT;
+
+        assembly {
+            sstore(implementationSlot_, newImplementation_)
+        }
+    }
+}

--- a/script/upgrade/UpgradeHubPortal.s.sol
+++ b/script/upgrade/UpgradeHubPortal.s.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.26;
 
 import { console } from "../../lib/forge-std/src/console.sol";
 
-import { UpgradeSpokePortalBase } from "./UpgradeSpokePortalBase.sol";
+import { UpgradeHubPortalBase } from "./UpgradeHubPortalBase.sol";
 
-contract UpgradeSpokePortal is UpgradeSpokePortalBase {
+contract UpgradeHubPortal is UpgradeHubPortalBase {
     function run() external {
         address deployer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
         (, address mToken_, address portal_, address registrar_,,) = _readDeployment(block.chainid);
@@ -14,7 +14,7 @@ contract UpgradeSpokePortal is UpgradeSpokePortalBase {
         console.log("Deployer:", deployer_);
         vm.startBroadcast(deployer_);
 
-        _upgradeSpokePortal(block.chainid, portal_, mToken_, registrar_, deployer_);
+        _upgradeHubPortal(portal_, mToken_, registrar_, deployer_);
 
         vm.stopBroadcast();
     }

--- a/script/upgrade/UpgradeHubPortalBase.sol
+++ b/script/upgrade/UpgradeHubPortalBase.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { ERC1967Proxy } from "../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { HubPortal } from "../../src/HubPortal.sol";
+
+import { Migrator } from "./Migrator.sol";
+import { ScriptBase } from "../ScriptBase.sol";
+
+abstract contract UpgradeHubPortalBase is ScriptBase {
+    function _upgradeHubPortal(address portal_, address mToken_, address registrar_, address deployer_) internal {
+        HubPortal implementation_ = new HubPortal(mToken_, registrar_);
+        Migrator migrator_ = new Migrator(address(implementation_));
+
+        HubPortal(portal_).migrate(address(migrator_));
+    }
+}

--- a/script/upgrade/UpgradeSpokePortal.s.sol
+++ b/script/upgrade/UpgradeSpokePortal.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { console } from "../../lib/forge-std/src/console.sol";
+
+import { UpgradeSpokePortalBase } from "./UpgradeSpokePortalBase.sol";
+
+contract UpgradeSpokePortal is UpgradeSpokePortalBase {
+    function run() external {
+        address deployer_ = vm.rememberKey(vm.envUint("PRIVATE_KEY"));
+        (address bridge_, address mToken_, address portal_, address registrar_,,) = _readDeployment(block.chainid);
+
+        console.log("Deployer:", deployer_);
+        vm.startBroadcast(deployer_);
+
+        _upgradeSpokePortal(block.chainid, portal_, mToken_, registrar_, bridge_, deployer_);
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/upgrade/UpgradeSpokePortalBase.sol
+++ b/script/upgrade/UpgradeSpokePortalBase.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.26;
+
+import { ERC1967Proxy } from "../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { Portal } from "../../src/Portal.sol";
+import { SpokePortal } from "../../src/SpokePortal.sol";
+
+import { Chains } from "../config/Chains.sol";
+import { Migrator } from "./Migrator.sol";
+import { ScriptBase } from "../ScriptBase.sol";
+
+abstract contract UpgradeSpokePortalBase is ScriptBase {
+    function _upgradeSpokePortal(
+        uint256 chainId_,
+        address portal_,
+        address mToken_,
+        address registrar_,
+        address bridge_,
+        address deployer_
+    ) internal {
+        SpokePortal implementation_ = new SpokePortal(Chains.getHubChainId(chainId_), mToken_, registrar_);
+        Migrator migrator_ = new Migrator(address(implementation_));
+
+        Portal(portal_).migrate(address(migrator_));
+    }
+}

--- a/script/upgrade/UpgradeSpokePortalBase.sol
+++ b/script/upgrade/UpgradeSpokePortalBase.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.26;
 
 import { ERC1967Proxy } from "../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
-import { Portal } from "../../src/Portal.sol";
 import { SpokePortal } from "../../src/SpokePortal.sol";
 
 import { Chains } from "../config/Chains.sol";
@@ -17,12 +16,11 @@ abstract contract UpgradeSpokePortalBase is ScriptBase {
         address portal_,
         address mToken_,
         address registrar_,
-        address bridge_,
         address deployer_
     ) internal {
         SpokePortal implementation_ = new SpokePortal(Chains.getHubChainId(chainId_), mToken_, registrar_);
         Migrator migrator_ = new Migrator(address(implementation_));
 
-        Portal(portal_).migrate(address(migrator_));
+        SpokePortal(portal_).migrate(address(migrator_));
     }
 }

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -226,7 +226,9 @@ abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuard
 
         // if the source token isn't M token, unwrap it
         if (sourceToken_ != address(mToken_)) {
-            IWrappedMTokenLike(sourceToken_).unwrap(address(this), amount_);
+            // NOTE: using low-level call to allow unwrap functions with and without return value
+            bool success = sourceToken_.safeCall(abi.encodeCall(IWrappedMTokenLike.unwrap, (address(this), amount_)));
+            if (!success) revert UnwrapFailed(sourceToken_, amount_);
         }
 
         // The actual amount of M tokens that Portal received from the sender.

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -135,6 +135,9 @@ interface IPortal {
     /// @notice Thrown when the destination chain id is equal to the source one.
     error InvalidDestinationChain(uint256 destinationChainId);
 
+    /// @notice Thrown when unwrapping `sourceToken` to M fails.
+    error UnwrapFailed(address sourceToken, uint256 amount);
+
     ///////////////////////////////////////////////////////////////////////////
     //                          VIEW/PURE FUNCTIONS                          //
     ///////////////////////////////////////////////////////////////////////////

--- a/test/fork/SpokePortalForkTest.t.sol
+++ b/test/fork/SpokePortalForkTest.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.26;
+
+import { Test } from "../../lib/forge-std/src/Test.sol";
+
+import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+import { IndexingMath } from "../../lib/common/src/libs/IndexingMath.sol";
+import { ERC1967Proxy } from "../../lib/openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { UpgradeSpokePortalBase } from "../../script/upgrade/UpgradeSpokePortalBase.sol";
+
+import { IPortal } from "../../src/interfaces/IPortal.sol";
+import { IMTokenLike } from "../../src/interfaces/IMTokenLike.sol";
+import { IRegistrarLike } from "../../src/interfaces/IRegistrarLike.sol";
+import { SpokePortal } from "../../src/SpokePortal.sol";
+import { HyperlaneBridge } from "../../src/bridges/hyperlane/HyperlaneBridge.sol";
+import { PayloadEncoder } from "../../src/libs/PayloadEncoder.sol";
+import { TypeConverter } from "../../src/libs/TypeConverter.sol";
+
+contract SpokePortalForkTest is Test, UpgradeSpokePortalBase {
+    uint256 public constant ETHEREUM_CHAIN_ID = 1;
+    uint256 public constant HYPEREVM_CHAIN_ID = 999;
+
+    address public constant DEPLOYER = 0xF2f1ACbe0BA726fEE8d75f3E32900526874740BB;
+
+    // The same addresses on Hyperevm and Ethereum
+    address public constant PORTAL = 0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE;
+    address public constant BRIDGE = 0x51DcE104E5ba88fabC19A2C519f955bb834b0DC3;
+    address public constant REGISTRAR = 0x119FbeeDD4F4f4298Fb59B720d5654442b81ae2c;
+    address public constant M_TOKEN = 0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b;
+    address public constant WRAPPED_M_TOKEN = 0x437cc33344a0B27A429f795ff6B469C72698B291;
+
+    address public constant USDHL = 0xb50A96253aBDF803D85efcDce07Ad8becBc52BD5;
+    address public constant USDHL_HOLDER = 0x77BAB32F75996de8075eBA62aEa7b1205cf7E004;
+    uint256 public constant HYPEREVM_FORK_BLOCK = 4_761_570;
+
+    uint256 public constant TOKEN_TRANSFER_GAS_LIMIT = 250_000;
+
+    function setUp() external {
+        vm.createSelectFork({ urlOrAlias: "hyperevm", blockNumber: HYPEREVM_FORK_BLOCK });
+
+        vm.deal(USDHL_HOLDER, 1 ether);
+    }
+
+    function test_transferUSDHL_reverts() external {
+        uint256 amount = 1000;
+        uint256 fee = IPortal(PORTAL).quoteTransfer(amount, ETHEREUM_CHAIN_ID, USDHL_HOLDER);
+
+        vm.startPrank(USDHL_HOLDER);
+
+        IERC20(USDHL).approve(PORTAL, amount);
+
+        // Reverts due to difference in unwrap function signature used by USDHL and Portal
+        vm.expectRevert();
+        IPortal(PORTAL).transferMLikeToken{ value: fee }(amount, USDHL, ETHEREUM_CHAIN_ID, M_TOKEN, USDHL_HOLDER, USDHL_HOLDER);
+
+        vm.stopPrank();
+    }
+
+    function test_upgradePortal_transferUSDHL() external {
+        vm.startPrank(DEPLOYER);
+        _upgradeSpokePortal(HYPEREVM_CHAIN_ID, PORTAL, M_TOKEN, REGISTRAR, BRIDGE, DEPLOYER);
+        vm.stopPrank();
+
+        uint256 amount = 100;
+        uint256 fee = IPortal(PORTAL).quoteTransfer(amount, ETHEREUM_CHAIN_ID, USDHL_HOLDER);
+
+        vm.startPrank(USDHL_HOLDER);
+
+        // Transfer USDHL that uses unwrap() function without return value
+        IERC20(USDHL).approve(PORTAL, amount);
+        IPortal(PORTAL).transferMLikeToken{ value: fee }(amount, USDHL, ETHEREUM_CHAIN_ID, M_TOKEN, USDHL_HOLDER, USDHL_HOLDER);
+
+        // Transfer wM that uses unwrap() function with return value
+        IERC20(WRAPPED_M_TOKEN).approve(PORTAL, amount);
+        IPortal(PORTAL).transferMLikeToken{ value: fee }(
+            amount, WRAPPED_M_TOKEN, ETHEREUM_CHAIN_ID, M_TOKEN, USDHL_HOLDER, USDHL_HOLDER
+        );
+
+        vm.stopPrank();
+    }
+}

--- a/test/fork/SpokePortalForkTest.t.sol
+++ b/test/fork/SpokePortalForkTest.t.sol
@@ -25,7 +25,6 @@ contract SpokePortalForkTest is Test, UpgradeSpokePortalBase {
 
     // The same addresses on Hyperevm and Ethereum
     address public constant PORTAL = 0x36f586A30502AE3afb555b8aA4dCc05d233c2ecE;
-    address public constant BRIDGE = 0x51DcE104E5ba88fabC19A2C519f955bb834b0DC3;
     address public constant REGISTRAR = 0x119FbeeDD4F4f4298Fb59B720d5654442b81ae2c;
     address public constant M_TOKEN = 0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b;
     address public constant WRAPPED_M_TOKEN = 0x437cc33344a0B27A429f795ff6B469C72698B291;
@@ -59,7 +58,7 @@ contract SpokePortalForkTest is Test, UpgradeSpokePortalBase {
 
     function test_upgradePortal_transferUSDHL() external {
         vm.startPrank(DEPLOYER);
-        _upgradeSpokePortal(HYPEREVM_CHAIN_ID, PORTAL, M_TOKEN, REGISTRAR, BRIDGE, DEPLOYER);
+        _upgradeSpokePortal(HYPEREVM_CHAIN_ID, PORTAL, M_TOKEN, REGISTRAR, DEPLOYER);
         vm.stopPrank();
 
         uint256 amount = 100;


### PR DESCRIPTION
### Motivation:
In `WrappedM v1` contract `unwrap()` function has the following signature:
`function unwrap(address recipient, uint256 amount) external returns (uint240 unwrapped); `
But for extensions we're using `unwrap()` function without return value:
`function unwrap(address recipient, uint256 amount) external;`
Portals are using `WrappedM` interface and as a result unwrapping of extensions fails.

### Proposed changes:
 - use low-level call to perform unwrap to allow calling functions with and without return value
 - add fork tests to reproduce the original issue and its mitigation after the upgrade
 - add `Migrator` contract
 - add scripts to upgrade Hub and Spoke Portals