### PR TITLE
feat: Original msg.sender propagation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 	path = lib/wrapped-m-token
 	url = git@github.com:m0-foundation/wrapped-m-token.git
 	branch = spoke
+[submodule "lib/uniswap-v4-periphery"]
+	path = lib/uniswap-v4-periphery
+	url = git@github.com:Uniswap/v4-periphery.git

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -5,8 +5,7 @@ pragma solidity 0.8.26;
 import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
 import { Migratable } from "../lib/common/src/Migratable.sol";
 import { IndexingMath } from "../lib/common/src/libs/IndexingMath.sol";
-import { ReentrancyGuardUpgradeable } from
-    "../lib/openzeppelin-contracts-upgradeable/contracts/utils/ReentrancyGuardUpgradeable.sol";
+import { ReentrancyLock } from "../lib/uniswap-v4-periphery/src/base/ReentrancyLock.sol";
 
 import { IPortal } from "./interfaces/IPortal.sol";
 import { IBridge } from "./interfaces/IBridge.sol";
@@ -22,7 +21,7 @@ import { PayloadType, PayloadEncoder } from "./libs/PayloadEncoder.sol";
  * @author M^0 Labs
  * @notice Base Portal contract inherited by HubPortal and SpokePortal.
  */
-abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuardUpgradeable, Migratable {
+abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyLock, Migratable {
     using TypeConverter for *;
     using PayloadEncoder for bytes;
     using SafeCall for address;
@@ -73,7 +72,6 @@ abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuard
     function _initialize(address bridge_, address initialOwner_, address initialPauser_) internal onlyInitializing {
         if ((bridge = bridge_) == address(0)) revert ZeroBridge();
         __PausableOwnable_init(initialOwner_, initialPauser_);
-        __ReentrancyGuard_init();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -98,6 +96,11 @@ abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuard
         return IBridge(bridge).quote(destinationChainId_, payloadGasLimit[destinationChainId_][PayloadType.Token], payload_);
     }
 
+    /// @inheritdoc IPortal
+    function msgSender() public view returns (address) {
+        return _getLocker();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     //                     EXTERNAL INTERACTIVE FUNCTIONS                    //
     ///////////////////////////////////////////////////////////////////////////
@@ -108,7 +111,7 @@ abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuard
         uint256 destinationChainId_,
         address recipient_,
         address refundAddress_
-    ) external payable whenNotPaused nonReentrant returns (bytes32 messageId_) {
+    ) external payable whenNotPaused isNotLocked returns (bytes32 messageId_) {
         return _transferMLikeToken(
             amount_, mToken, destinationChainId_, destinationMToken[destinationChainId_], recipient_, refundAddress_
         );
@@ -122,7 +125,7 @@ abstract contract Portal is IPortal, PausableOwnableUpgradeable, ReentrancyGuard
         address destinationToken_,
         address recipient_,
         address refundAddress_
-    ) external payable whenNotPaused nonReentrant returns (bytes32 messageId_) {
+    ) external payable whenNotPaused isNotLocked returns (bytes32 messageId_) {
         if (!supportedBridgingPath[sourceToken_][destinationChainId_][destinationToken_]) {
             revert UnsupportedBridgingPath(sourceToken_, destinationChainId_, destinationToken_);
         }

--- a/src/interfaces/IPortal.sol
+++ b/src/interfaces/IPortal.sol
@@ -158,7 +158,10 @@ interface IPortal {
     function bridge() external view returns (address);
 
     /// @notice The address of the Swap Facility contract.
-    function swapFacility() external view returns (address swapFacility);
+    function swapFacility() external view returns (address);
+
+    /// @notice The address of the original caller of `transfer` and `transferMLikeToken` functions.
+    function msgSender() external view returns (address);
 
     /**
      * @notice Returns the address of M token on the destination chain.


### PR DESCRIPTION
### Description:

Similar to `UniswapV3SwapAdapter`, `Portal` contracts need to expose `msgSender` function, so that `SwapFacility` can use it to identify the original caller.