### PR TITLE
chore: use Locker with persistent storage for Linea

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,7 +6,7 @@ solc_version = "0.8.26"
 optimizer = true
 optimizer-runs = 10_000
 verbosity = 3
-evm_version = "cancun"
+evm_version = "london"
 fs_permissions = [{ access = "read-write", path = "./deployments" }]
 
 ignored_warnings_from = ["lib", "test", "script"]

--- a/src/Portal.sol
+++ b/src/Portal.sol
@@ -5,7 +5,6 @@ pragma solidity 0.8.26;
 import { IERC20 } from "../lib/common/src/interfaces/IERC20.sol";
 import { Migratable } from "../lib/common/src/Migratable.sol";
 import { IndexingMath } from "../lib/common/src/libs/IndexingMath.sol";
-import { ReentrancyLock } from "../lib/uniswap-v4-periphery/src/base/ReentrancyLock.sol";
 
 import { IPortal } from "./interfaces/IPortal.sol";
 import { IBridge } from "./interfaces/IBridge.sol";
@@ -14,6 +13,7 @@ import { PausableOwnableUpgradeable } from "./access/PausableOwnableUpgradeable.
 import { TypeConverter } from "./libs/TypeConverter.sol";
 import { SafeCall } from "./libs/SafeCall.sol";
 import { PayloadType, PayloadEncoder } from "./libs/PayloadEncoder.sol";
+import { ReentrancyLock } from "./libs/ReentrancyLock.sol";
 
 /**
  * @title  Portal

--- a/src/libs/Locker.sol
+++ b/src/libs/Locker.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/**
+    * @author Uniswap Labs.
+    *         Adapted from https://github.com/Uniswap/v4-periphery/blob/main/src/libraries/Locker.sol for Linea deployment.
+    * @dev    Use Uniswap version of the contract when Linea supports transient storage.
+ */
+library Locker {
+    // The slot holding the locker state. bytes32(uint256(keccak256("LockedBy")) - 1)
+    bytes32 constant LOCKED_BY_SLOT = 0x0aedd6bde10e3aa2adec092b02a3e3e805795516cda41f27aa145b8f300af87a;
+
+    function set(address locker) internal {
+        assembly {
+            sstore(LOCKED_BY_SLOT, locker)
+        }
+    }
+
+    function get() internal view returns (address locker) {
+        assembly {
+            locker := sload(LOCKED_BY_SLOT)
+        }
+    }
+}

--- a/src/libs/ReentrancyLock.sol
+++ b/src/libs/ReentrancyLock.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Locker } from "./Locker.sol";
+
+/**
+    * @author Uniswap Labs.
+    *         Copied from https://github.com/Uniswap/v4-periphery/blob/main/src/base/ReentrancyLock.sol.
+    * @dev    Use Uniswap version of the contract when Linea supports transient storage.
+ */
+contract ReentrancyLock {
+    error ContractLocked();
+
+    modifier isNotLocked() {
+        if (Locker.get() != address(0)) revert ContractLocked();
+        Locker.set(msg.sender);
+        _;
+        Locker.set(address(0));
+    }
+
+    function _getLocker() internal view returns (address) {
+        return Locker.get();
+    }
+}


### PR DESCRIPTION
### Description
Linea doesn't support `TLOAD` and `TSTORE` OP codes. See https://docs.linea.build/get-started/build/ethereum-differences#evm-opcodes
These OP Codes are used in [Uniswap Locker](https://github.com/Uniswap/v4-periphery/blob/main/src/libraries/Locker.sol) contract which we use `Portal`.
So, the current version of these contracts cannot be deployed to Linea.

### Poposed changes
Modify Uniswap's `Locker` contract that uses `SLOAD` and `SSTORE` instead of `TLOAD` and `TSTORE`.

### Note
The fix is temporary as Linea will be supporting transient storage in the future. 
Do not merge into main branch.