### PR TITLE
feat: migrate $M to main Portal

### DIFF
--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -22,6 +22,9 @@ import { PayloadType, PayloadEncoder } from "./libs/PayloadEncoder.sol";
  * @dev    Tokens are bridged using lock-release mechanism.
  */
 contract HubPortal is Portal, IHubPortal {
+    address public constant MAIN_PORTAL = 0xD925C84b55E4e44a53749fF5F2a5A13F63D128fd;
+    address public constant MIGRATOR = 0xb7A9B5f301eF3bAD36C2b4964E82931Dd7fb989C;
+
     /// @inheritdoc IHubPortal
     bool public wasEarningEnabled;
 
@@ -148,6 +151,16 @@ contract HubPortal is Portal, IHubPortal {
         IMTokenLike(mToken).stopEarning(address(this));
 
         emit EarningDisabled(currentMIndex_);
+    }
+
+    /// @inheritdoc IHubPortal
+    function migrateM(uint256 amount) external whenPaused {
+        if (msg.sender != MIGRATOR) revert Unauthorized(msg.sender);
+
+        uint256 balance = IERC20(mToken).balanceOf(address(this));
+        if (amount > balance) revert InsufficientBalance(balance, amount);
+
+        IERC20(mToken).transfer(MAIN_PORTAL, amount);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/HubPortal.sol
+++ b/src/HubPortal.sol
@@ -154,7 +154,7 @@ contract HubPortal is Portal, IHubPortal {
     }
 
     /// @inheritdoc IHubPortal
-    function migrateM(uint256 amount) external whenPaused {
+    function migrateM(uint256 amount) external {
         if (msg.sender != MIGRATOR) revert Unauthorized(msg.sender);
 
         uint256 balance = IERC20(mToken).balanceOf(address(this));

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -74,6 +74,9 @@ interface IHubPortal is IPortal {
     /// @notice Thrown when performing an operation that is not allowed when earning is enabled.
     error EarningIsEnabled();
 
+    /// @notice Thrown when trying to migrate more $M tokens than Portal holds.
+    error InsufficientBalance(uint256 balance, uint256 amount);
+
     /// @notice Thrown when trying to unlock more tokens than was locked.
     error InsufficientBridgedBalance();
 
@@ -176,4 +179,11 @@ interface IHubPortal is IPortal {
      * @param  spokeChainId The EVM chain Id of the Spoke chain.
      */
     function enableCrossSpokeConnection(uint256 spokeChainId) external;
+
+    /**
+     * @notice Migrates $M tokens to the main Portal.
+     * @dev    Can only be called by the migrator when the contract is paused.
+     * @param  amount The amount of $M tokens to migrate.
+     */
+    function migrateM(uint256 amount) external;
 }

--- a/src/interfaces/IHubPortal.sol
+++ b/src/interfaces/IHubPortal.sol
@@ -182,7 +182,6 @@ interface IHubPortal is IPortal {
 
     /**
      * @notice Migrates $M tokens to the main Portal.
-     * @dev    Can only be called by the migrator when the contract is paused.
      * @param  amount The amount of $M tokens to migrate.
      */
     function migrateM(uint256 amount) external;

--- a/test/unit/HubPortalTest.t.sol
+++ b/test/unit/HubPortalTest.t.sol
@@ -697,4 +697,89 @@ contract HubPortalTest is Test {
         vm.expectRevert(IPortal.NotBridge.selector);
         hubPortal.receiveMessage(SPOKE_CHAIN_ID, bytes("payload"));
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    //                               migrateM                                //
+    ///////////////////////////////////////////////////////////////////////////
+
+    function test_migrateM() external {
+        uint256 amount_ = 1000;
+
+        // Mint M tokens to the portal
+        mToken.mint(address(hubPortal), amount_);
+
+        // Pause the contract
+        vm.prank(owner);
+        hubPortal.pause();
+
+        // Migrate M tokens
+        vm.prank(hubPortal.MIGRATOR());
+        hubPortal.migrateM(amount_);
+
+        // Verify tokens were transferred to MAIN_PORTAL
+        assertEq(mToken.balanceOf(address(hubPortal)), 0);
+        assertEq(mToken.balanceOf(hubPortal.MAIN_PORTAL()), amount_);
+    }
+
+    function test_migrateM_partialAmount() external {
+        uint256 balance_ = 1000;
+        uint256 amount_ = 500;
+
+        // Mint M tokens to the portal
+        mToken.mint(address(hubPortal), balance_);
+
+        // Pause the contract
+        vm.prank(owner);
+        hubPortal.pause();
+
+        // Migrate partial amount
+        vm.prank(hubPortal.MIGRATOR());
+        hubPortal.migrateM(amount_);
+
+        // Verify correct amount transferred
+        assertEq(mToken.balanceOf(address(hubPortal)), balance_ - amount_);
+        assertEq(mToken.balanceOf(hubPortal.MAIN_PORTAL()), amount_);
+    }
+
+    function test_migrateM_notPaused() external {
+        uint256 amount_ = 1000;
+        address migrator_ = hubPortal.MIGRATOR();
+
+        mToken.mint(address(hubPortal), amount_);
+
+        vm.expectRevert(PausableUpgradeable.ExpectedPause.selector);
+        vm.prank(migrator_);
+        hubPortal.migrateM(amount_);
+    }
+
+    function test_migrateM_unauthorized() external {
+        uint256 amount_ = 1000;
+
+        mToken.mint(address(hubPortal), amount_);
+
+        // Pause the contract
+        vm.prank(owner);
+        hubPortal.pause();
+
+        vm.expectRevert(abi.encodeWithSelector(IPausableOwnable.Unauthorized.selector, user));
+        vm.prank(user);
+        hubPortal.migrateM(amount_);
+    }
+
+    function test_migrateM_insufficientBalance() external {
+        uint256 balance_ = 500;
+        uint256 amount_ = 1000;
+        address migrator_ = hubPortal.MIGRATOR();
+
+        // Mint less M tokens than requested
+        mToken.mint(address(hubPortal), balance_);
+
+        // Pause the contract
+        vm.prank(owner);
+        hubPortal.pause();
+
+        vm.expectRevert(abi.encodeWithSelector(IHubPortal.InsufficientBalance.selector, balance_, amount_));
+        vm.prank(migrator_);
+        hubPortal.migrateM(amount_);
+    }
 }

--- a/test/unit/HubPortalTest.t.sol
+++ b/test/unit/HubPortalTest.t.sol
@@ -741,17 +741,6 @@ contract HubPortalTest is Test {
         assertEq(mToken.balanceOf(hubPortal.MAIN_PORTAL()), amount_);
     }
 
-    function test_migrateM_notPaused() external {
-        uint256 amount_ = 1000;
-        address migrator_ = hubPortal.MIGRATOR();
-
-        mToken.mint(address(hubPortal), amount_);
-
-        vm.expectRevert(PausableUpgradeable.ExpectedPause.selector);
-        vm.prank(migrator_);
-        hubPortal.migrateM(amount_);
-    }
-
     function test_migrateM_unauthorized() external {
         uint256 amount_ = 1000;
 


### PR DESCRIPTION
### Motivation 

Update the HubPortal Lite to enable transferring locked $M tokens from Portal Lite to Portal V2.

The migration from Portal Lite will be performed on a chain-by-chain basis, depending on partner readiness.

Only the engineering multisig - `0xb7A9B5f301eF3bAD36C2b4964E82931Dd7fb989C` - can transfer the locked $M tokens.